### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.10.txt
+++ b/requirements/dev_3.10.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -342,7 +340,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   mando
     #   patsy
     #   python-dateutil

--- a/requirements/dev_3.11.txt
+++ b/requirements/dev_3.11.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -340,7 +338,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   mando
     #   patsy
     #   python-dateutil

--- a/requirements/dev_3.8.txt
+++ b/requirements/dev_3.8.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -346,7 +344,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   mando
     #   patsy
     #   python-dateutil

--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -344,7 +342,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   mando
     #   patsy
     #   python-dateutil

--- a/requirements/main_3.10.txt
+++ b/requirements/main_3.10.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -229,7 +227,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   patsy
     #   python-dateutil
 stack-data==0.6.2

--- a/requirements/main_3.11.txt
+++ b/requirements/main_3.11.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -229,7 +227,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   patsy
     #   python-dateutil
 stack-data==0.6.2

--- a/requirements/main_3.8.txt
+++ b/requirements/main_3.8.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -233,7 +231,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   patsy
     #   python-dateutil
 stack-data==0.6.2

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -12,8 +12,6 @@ anndata==0.9.1
     # via
     #   infercnvpy
     #   scanpy
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -231,7 +229,6 @@ session-info==1.0.0
     #   scanpy
 six==1.16.0
     # via
-    #   asttokens
     #   patsy
     #   python-dateutil
 stack-data==0.6.2


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

python
	 version: 3.9.14
	location: /usr/local/bin/python
roadie
	 version: 6.4.1
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10, 3.11
✓ Attempting to lock for Python 3.8
✓ Attempting to lock for Python 3.10
✓ Attempting to lock for Python 3.9
✓ Attempting to lock for Python 3.11
Skipping Python 3.7

```